### PR TITLE
make apply() pure Python/numpy to get broadcasting

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
 
+import sys
 import timeit
 
-# functions
+args = sys.argv[1:]
+if len(args) == 0:
+    args = ['ccm89', 'fitzpatrick99', 'apply']
 
-setup = """
+if 'ccm89' in args:
+    setup = """
 import numpy
 from extinction import {name}
 wave = numpy.logspace(numpy.log10({minwave}),
@@ -13,57 +17,59 @@ wave = numpy.logspace(numpy.log10({minwave}),
                       {size:d})
 """
 
-stmt = "{name}(wave, 1.0, 3.1)"
+    stmt = "{name}(wave, 1.0, 3.1)"
 
-benchmarks = [
-    {'name': 'ccm89',
-     'minwave': 1000., 'maxwave': 30000., 'size': 10, 'nloops': 1000000},
-    {'name': 'ccm89',
-     'minwave': 1000., 'maxwave': 30000., 'size': 100, 'nloops': 100000},
-    {'name': 'ccm89',
-     'minwave': 1000., 'maxwave': 30000., 'size': 1000, 'nloops': 10000},
-    {'name': 'ccm89',
-     'minwave': 1000., 'maxwave': 30000., 'size': 10000, 'nloops': 1000},
-    {'name': 'od94',
-     'minwave': 1000., 'maxwave': 30000., 'size': 100, 'nloops': 100000},
-    {'name': 'ccm89',
-     'minwave': 1000., 'maxwave': 1e4/8, 'size': 100, 'nloops': 100000},
-    {'name': 'ccm89',
-     'minwave': 1e4/8, 'maxwave': 1e4/3.3, 'size': 100, 'nloops': 100000},
-    {'name': 'ccm89',
-     'minwave': 1e4/3.3, 'maxwave': 1e4/1.1, 'size': 100, 'nloops': 100000},
-    {'name': 'ccm89',
-     'minwave': 1e4/1.1, 'maxwave': 1e4/0.3, 'size': 100, 'nloops': 100000}]
-for b in benchmarks:
-    times = timeit.repeat(stmt.format(**b), setup=setup.format(**b),
-                          repeat=3, number=b['nloops'])
-    b['time'] = min(times) / b['nloops'] * 1e6
-    print('{name:5s}  wave=[{minwave: 7.1f}, {maxwave: 7.1f}]  size={size:5d}  {time:8.2f}us'.format(**b))
+    benchmarks = [
+        {'name': 'ccm89',
+         'minwave': 1000., 'maxwave': 30000., 'size': 10, 'nloops': 1000000},
+        {'name': 'ccm89',
+         'minwave': 1000., 'maxwave': 30000., 'size': 100, 'nloops': 100000},
+        {'name': 'ccm89',
+         'minwave': 1000., 'maxwave': 30000., 'size': 1000, 'nloops': 10000},
+        {'name': 'ccm89',
+         'minwave': 1000., 'maxwave': 30000., 'size': 10000, 'nloops': 1000},
+        {'name': 'odonnell94',
+         'minwave': 1000., 'maxwave': 30000., 'size': 100, 'nloops': 100000},
+        {'name': 'ccm89',
+         'minwave': 1000., 'maxwave': 1e4/8, 'size': 100, 'nloops': 100000},
+        {'name': 'ccm89',
+         'minwave': 1e4/8, 'maxwave': 1e4/3.3, 'size': 100, 'nloops': 100000},
+        {'name': 'ccm89',
+         'minwave': 1e4/3.3, 'maxwave': 1e4/1.1, 'size': 100, 'nloops': 100000},
+        {'name': 'ccm89',
+         'minwave': 1e4/1.1, 'maxwave': 1e4/0.3, 'size': 100, 'nloops': 100000}]
+    for b in benchmarks:
+        times = timeit.repeat(stmt.format(**b), setup=setup.format(**b),
+                              repeat=3, number=b['nloops'])
+        b['time'] = min(times) / b['nloops'] * 1e6
+        print('{name:5s}  wave=[{minwave: 7.1f}, {maxwave: 7.1f}]  size={size:5d}  {time:8.2f}us'.format(**b))
 
 
-print()
+    print()
 
-# -----------------------------------------------------------------------
-# Fitzpatrick init
-setup = """
+if 'fitzpatrick99' in args:
+    
+    # -----------------------------------------------------------------------
+    # Fitzpatrick init
+    setup = """
+    import numpy
+    from extinction import F99
+    """
+
+    stmt = "F99(3.1)"
+
+    nloops = 10000
+    times = timeit.repeat(stmt, setup=setup, repeat=3, number=nloops)
+    t = min(times) / nloops * 1e6
+    print('F99 init              {:8.2f}us'.format(t))
+
+
+    #------------------------------------------------------------------------
+    # Fitzpatrick fast method
+
+    setup = """
 import numpy
-from extinction import F99
-"""
-
-stmt = "F99(3.1)"
-
-nloops = 10000
-times = timeit.repeat(stmt, setup=setup, repeat=3, number=nloops)
-t = min(times) / nloops * 1e6
-print('F99 init              {:8.2f}us'.format(t))
-
-
-#------------------------------------------------------------------------
-# Fitzpatrick fast method
-
-setup = """
-import numpy
-from extinction import F99
+from extinction import Fitzpatrick99
 
 wave = numpy.logspace(numpy.log10({minwave}),
                       numpy.log10({maxwave}),
@@ -71,45 +77,44 @@ wave = numpy.logspace(numpy.log10({minwave}),
 f = F99(3.1)
 """
 
-stmt = "f(wave, 1.0)"
+    stmt = "f(wave, 1.0)"
 
-benchmarks = [
-    {'minwave': 1000., 'maxwave': 30000., 'size': 10, 'nloops': 10000},
-    {'minwave': 1000., 'maxwave': 30000., 'size': 100, 'nloops': 10000},
-    {'minwave': 1000., 'maxwave': 30000., 'size': 1000, 'nloops': 10000},
-    {'minwave': 1000., 'maxwave': 30000., 'size': 10000, 'nloops': 1000},
-    {'minwave': 1000., 'maxwave': 2700.,  'size': 1000, 'nloops': 10000},
-    {'minwave': 2700., 'maxwave': 30000., 'size': 1000, 'nloops': 10000}]
-for b in benchmarks:
-    times = timeit.repeat(stmt.format(**b), setup=setup.format(**b),
-                          repeat=3, number=b['nloops'])
-    b['time'] = min(times) / b['nloops'] * 1e6
-    print('F99 call  wave=[{minwave: 7.1f}, {maxwave: 7.1f}]  size={size:5d}  {time:8.2f}us'.format(**b))
+    benchmarks = [
+        {'minwave': 1000., 'maxwave': 30000., 'size': 10, 'nloops': 10000},
+        {'minwave': 1000., 'maxwave': 30000., 'size': 100, 'nloops': 10000},
+        {'minwave': 1000., 'maxwave': 30000., 'size': 1000, 'nloops': 10000},
+        {'minwave': 1000., 'maxwave': 30000., 'size': 10000, 'nloops': 1000},
+        {'minwave': 1000., 'maxwave': 2700.,  'size': 1000, 'nloops': 10000},
+        {'minwave': 2700., 'maxwave': 30000., 'size': 1000, 'nloops': 10000}]
+    for b in benchmarks:
+        times = timeit.repeat(stmt.format(**b), setup=setup.format(**b),
+                              repeat=3, number=b['nloops'])
+        b['time'] = min(times) / b['nloops'] * 1e6
+        print('Fitzpatrick99 call  wave=[{minwave: 7.1f}, {maxwave: 7.1f}]  size={size:5d}  {time:8.2f}us'.format(**b))
 
-# ------------------------------------------------------------------------
-# apply
 
-setup = """
+if 'apply' in args:
+
+    setup = """
 import numpy
 from extinction import apply
-
 ext = numpy.ones({size:d})
 flux = numpy.ones({size:d})
 """
 
-stmt = "apply(ext, flux, inplace={inplace!r})"
+    stmt = "apply(ext, flux, inplace={inplace!r})"
 
-benchmarks = [
-    {'size': 10, 'nloops': 100000, 'inplace': True},
-    {'size': 10, 'nloops': 100000, 'inplace': False},
-    {'size': 100, 'nloops': 100000, 'inplace': True},
-    {'size': 100, 'nloops': 100000, 'inplace': False},
-    {'size': 1000, 'nloops': 10000, 'inplace': False}]
-for b in benchmarks:
-    times = timeit.repeat(stmt.format(**b), setup=setup.format(**b),
-                          repeat=3, number=b['nloops'])
-    b['time'] = min(times) / b['nloops'] * 1e6
-    print('apply  size={size:5d} inplace={inplace!r} {time:8.2f}us'.format(**b))
+    benchmarks = [
+        {'size': 10, 'nloops': 100000, 'inplace': True},
+        {'size': 10, 'nloops': 100000, 'inplace': False},
+        {'size': 100, 'nloops': 100000, 'inplace': True},
+        {'size': 100, 'nloops': 100000, 'inplace': False},
+        {'size': 1000, 'nloops': 10000, 'inplace': False}]
+    for b in benchmarks:
+        times = timeit.repeat(stmt.format(**b), setup=setup.format(**b),
+                              repeat=3, number=b['nloops'])
+        b['time'] = min(times) / b['nloops'] * 1e6
+        print('apply  size={size:5d} inplace={inplace!r} {time:8.2f}us'.format(**b))
 
 
 #def benchmark(f, args, repeat=3):

--- a/extinction.pyx
+++ b/extinction.pyx
@@ -650,7 +650,7 @@ def calzetti00(double[:] wave, double a_v, double r_v, unit='aa',
 # in-place. (It turns out that this isn't really faster than just doing it
 # in pure python...)
 
-def apply(double[:] extinction, np.ndarray flux not None, bint inplace=False):
+def apply(extinction, flux, inplace=False):
     """apply(extinction, flux, inplace=False)
 
     Apply extinction to flux values (optionally in-place).
@@ -663,8 +663,8 @@ def apply(double[:] extinction, np.ndarray flux not None, bint inplace=False):
     extinction : numpy.ndarray (1-d)
         Extinction in magnitudes. (Positive extinction values decrease flux
         values.)
-    flux : numpy.ndarray (1-d)
-        Flux values. Shape must match extinction.
+    flux : numpy.ndarray
+        Flux values.
     inplace : bool, optional
         Whether to perform the operation in-place on the flux array. If True,
         the return value is a reference to the input flux array.
@@ -675,21 +675,10 @@ def apply(double[:] extinction, np.ndarray flux not None, bint inplace=False):
         Flux values with extinction applied.
     """
 
-    cdef size_t i
-    cdef size_t n = extinction.shape[0]
-    cdef double[:] out_view
-    cdef double[:] flux_view = flux
-
-    if not extinction.shape[0] == flux.shape[0]:
-        raise ValueError("shape of flux and extinction must match")
+    trans = 10.**(-0.4 * extinction)
 
     if inplace:
-        out = flux
+        flux *= trans
+        return flux
     else:
-        out = np.empty(n, dtype=np.float)
-
-    out_view = out
-    for i in range(n):
-        out_view[i] = 10.**(-0.4 * extinction[i]) * flux_view[i]
-
-    return out
+        return flux * trans


### PR DESCRIPTION
apply() is now about 20% slower for inplace operations, but about the
same for non-inplace operations. Seems like a reasonable tradeoff for
the win of getting broadcasting behavior.