### PR TITLE
Add extinction.correct() convenience function

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Usage
    extinction.fitzpatrick99
    extinction.fm07
    extinction.apply
+   extinction.correct
 
 **Classes:**
 
@@ -84,7 +85,7 @@ Redden or deredden
 ..................
 
 To "redden" or "deredden" flux values by some amount, use the
-``apply`` convenience function::
+``apply`` and ``correct`` convenience functions::
 
 
   >>> from extinction import ccm89, apply
@@ -96,7 +97,7 @@ To "redden" or "deredden" flux values by some amount, use the
   array([ 0.07294397,  0.25952412,  0.5767723 ])
 
   # "deredden" flux by A_V = 1.0
-  >>> apply(ccm89(wave, -1.0, 3.1), flux)
+  >>> correct(ccm89(wave, 1.0, 3.1), flux)
   array([ 13.70915145,   3.85320647,   1.73378645])
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ Usage
    extinction.fitzpatrick99
    extinction.fm07
    extinction.apply
-   extinction.correct
+   extinction.remove
 
 **Classes:**
 
@@ -85,7 +85,7 @@ Redden or deredden
 ..................
 
 To "redden" or "deredden" flux values by some amount, use the
-``apply`` and ``correct`` convenience functions::
+``apply`` and ``remove`` convenience functions::
 
 
   >>> from extinction import ccm89, apply
@@ -97,7 +97,7 @@ To "redden" or "deredden" flux values by some amount, use the
   array([ 0.07294397,  0.25952412,  0.5767723 ])
 
   # "deredden" flux by A_V = 1.0
-  >>> correct(ccm89(wave, 1.0, 3.1), flux)
+  >>> remove(ccm89(wave, 1.0, 3.1), flux)
   array([ 13.70915145,   3.85320647,   1.73378645])
 
 

--- a/extinction.pyx
+++ b/extinction.pyx
@@ -9,7 +9,7 @@ cimport numpy as np
 __version__ = "0.3.0"
 
 __all__ = ['ccm89', 'odonnell94', 'Fitzpatrick99', 'fitzpatrick99', 'fm07',
-           'calzetti00', 'apply', 'correct']
+           'calzetti00', 'apply', 'remove']
 
 
 # We use some C code for Cubic splines in the Fitzpatrick99 and fm07 functions.
@@ -756,16 +756,16 @@ def apply(extinction, flux, inplace=False):
         return flux * trans
 
 # ------------------------------------------------------------------------------
-# convenience function for correcting observed flux values for extinction,
-# optionally in-place. (It turns out that this isn't really faster than just doing it
+# convenience function for removing extinction from flux values, optionally
+# in-place. (It turns out that this isn't really faster than just doing it
 # in pure python...)
 
-def correct(extinction, flux, inplace=False):
-    """correct(extinction, flux, inplace=False)
+def remove(extinction, flux, inplace=False):
+    """remove(extinction, flux, inplace=False)
 
-    Correct flux values for extinction (optionally in-place).
+    Remove extinction from observed flux values (optionally in-place).
 
-    This is a convenience function to "deredden" flux values. It simply performs 
+    This is a convenience function to "deredden" fluxes. It simply performs 
     ``flux * 10**(0.4 * extinction)``.
 
     Parameters
@@ -781,7 +781,7 @@ def correct(extinction, flux, inplace=False):
     Returns
     -------
     new_flux : numpy.ndarray (1-d)
-        Flux values corrected for extinction.
+        Flux values with extinction removed.
     """
 
     trans = 10.**(0.4 * extinction)

--- a/extinction.pyx
+++ b/extinction.pyx
@@ -9,7 +9,7 @@ cimport numpy as np
 __version__ = "0.3.0"
 
 __all__ = ['ccm89', 'odonnell94', 'Fitzpatrick99', 'fitzpatrick99', 'fm07',
-           'calzetti00', 'apply']
+           'calzetti00', 'apply', 'correct']
 
 
 # We use some C code for Cubic splines in the Fitzpatrick99 and fm07 functions.
@@ -748,6 +748,43 @@ def apply(extinction, flux, inplace=False):
     """
 
     trans = 10.**(-0.4 * extinction)
+
+    if inplace:
+        flux *= trans
+        return flux
+    else:
+        return flux * trans
+
+# ------------------------------------------------------------------------------
+# convenience function for correcting observed flux values for extinction,
+# optionally in-place. (It turns out that this isn't really faster than just doing it
+# in pure python...)
+
+def correct(extinction, flux, inplace=False):
+    """correct(extinction, flux, inplace=False)
+
+    Correct flux values for extinction (optionally in-place).
+
+    This is a convenience function to "deredden" flux values. It simply performs 
+    ``flux * 10**(0.4 * extinction)``.
+
+    Parameters
+    ----------
+    extinction : numpy.ndarray (1-d)
+        Extinction in magnitudes.
+    flux : numpy.ndarray
+        Flux values.
+    inplace : bool, optional
+        Whether to perform the operation in-place on the flux array. If True,
+        the return value is a reference to the input flux array.
+
+    Returns
+    -------
+    new_flux : numpy.ndarray (1-d)
+        Flux values corrected for extinction.
+    """
+
+    trans = 10.**(0.4 * extinction)
 
     if inplace:
         flux *= trans


### PR DESCRIPTION
Adding this function makes the procedure required to correct observed
fluxes for extinction clearer. A new user trying to de-redden fluxes
might mistakenly use extinction.apply() with the output of one of the
extinction functions and wind up reddening rather than de-reddening
their observations.

* Copy/pasted extinction.apply() and made relevant changes.
* Modified documentation index.rst to make de-reddening procedure clear.
* Added extinction.correct() docstring to index.rst