### PR TITLE
Add PEP 517 compliant pyproject.toml

### DIFF
--- a/extinction.pyx
+++ b/extinction.pyx
@@ -6,7 +6,7 @@
 import numpy as np
 cimport numpy as np
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __all__ = ['ccm89', 'odonnell94', 'Fitzpatrick99', 'fitzpatrick99', 'fm07',
            'calzetti00', 'apply', 'remove']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,9 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython>=0.29.2",
+    "numpy==1.13.3; python_version=='3.5'",
+    "numpy==1.13.3; python_version=='3.6'",
+    "numpy==1.14.5; python_version>='3.7'",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy", "Cython"]
-build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -5,24 +5,24 @@ from setuptools.extension import Extension
 import re
 
 import numpy
+from Cython.Build import cythonize
 
-if os.path.exists("extinction.pyx"):
-    USE_CYTHON = True
-    fname = "extinction.pyx"
-else:
-    USE_CYTHON = False
-    fname = "extinction.c"
+fname = "extinction.pyx"
 
 sourcefiles = [fname, os.path.join("extern", "bs.c")]
-dependsfiles = [os.path.join("extern", "bs.h"),
-                os.path.join("extern", "bsplines.pxi")]
+dependsfiles = [os.path.join("extern", "bs.h"), os.path.join("extern", "bsplines.pxi")]
 include_dirs = [numpy.get_include(), "extern"]
-extensions = [Extension("extinction", sourcefiles, include_dirs=include_dirs,
-                        depends=dependsfiles, extra_compile_args=['-std=c99'])]
+extensions = [
+    Extension(
+        "extinction",
+        sourcefiles,
+        include_dirs=include_dirs,
+        depends=dependsfiles,
+        extra_compile_args=["-std=c99"],
+    )
+]
 
-if USE_CYTHON:
-    from Cython.Build import cythonize
-    extensions = cythonize(extensions)
+extensions = cythonize(extensions)
 
 # Synchronize version from code.
 version = re.findall(r"__version__ = \"(.*?)\"", open(fname).read())[0]
@@ -33,16 +33,19 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Topic :: Scientific/Engineering :: Astronomy",
-    "Intended Audience :: Science/Research"]
+    "Intended Audience :: Science/Research",
+]
 
-setup(name="extinction", 
-      version=version,
-      description="Fast interstellar dust extinction laws",
-      long_description="documentation: http://extinction.readthedocs.io",
-      license="MIT",
-      classifiers=classifiers,
-      url="http://github.com/kbarbary/extinction",
-      author="Kyle Barbary",
-      author_email="kylebarbary@gmail.com",
-      ext_modules=extensions,
-      install_requires=["numpy"])
+setup(
+    name="extinction",
+    version=version,
+    description="Fast interstellar dust extinction laws",
+    long_description="documentation: http://extinction.readthedocs.io",
+    license="MIT",
+    classifiers=classifiers,
+    url="http://github.com/kbarbary/extinction",
+    author="Kyle Barbary",
+    author_email="kylebarbary@gmail.com",
+    ext_modules=extensions,
+    install_requires=["numpy"],
+)

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
     author="Kyle Barbary",
     author_email="kylebarbary@gmail.com",
     ext_modules=extensions,
-    install_requires=["numpy"],
+    install_requires=["numpy>=1.13.3"],
 )


### PR DESCRIPTION
Hello,

I've made a pull request that adds a `pyproject.toml` file which allows specifying `Cython` and `numpy` as *build* dependencies. This means that anybody using `pip` to install will install those before trying to compile the extensions. If still using `python setup.py` it will require the user to install the dependencies by hand before. 

This is convenient when considering using `extinction` as a dependency so that it is more stable when being built in fresh environments. 

I've also bumped the version to `0.4.1` in an effort to ask for a PyPI release :)