### PR TITLE
Update pyproject.toml

### DIFF
--- a/extinction.pyx
+++ b/extinction.pyx
@@ -6,7 +6,7 @@
 import numpy as np
 cimport numpy as np
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = ['ccm89', 'odonnell94', 'Fitzpatrick99', 'fitzpatrick99', 'fm07',
            'calzetti00', 'apply', 'remove']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = [
     "wheel",
     "setuptools",


### PR DESCRIPTION
without specifying the setuptools build-backend pyproject.toml does not actually work.

MWE of failure with docker:
```
$ docker run --rm -ti python bash
$ pip install extinction==0.4.1
[...]
module numpy not found
```